### PR TITLE
fixed swmm and dyna export

### DIFF
--- a/qkan/dynaporter/dialogs.py
+++ b/qkan/dynaporter/dialogs.py
@@ -417,21 +417,25 @@ class ExportDialog(QKanDBDialog, EXPORT_CLASS):  # type: ignore
                 )"""
                 )
                 try:
-                    export_kanaldaten(
-                        self.iface,
-                        dynafile,
-                        template_dyna,
-                        db_qkan,
-                        dynabef_choice,
-                        dynaprof_choice,
-                        liste_teilgebiete,
-                        profile_ergaenzen,
-                        autonummerierung_dyna,
-                        mit_verschneidung,
-                        fangradius,
-                        mindestflaeche,
-                        max_loops,
-                    )
+                    # the previous connection might be stale when this point is 
+                    # reached (actually it should always be stale), causing this
+                    # function to fail. creating a new connection fixes this
+                    with DBConnection(dbname=database_qkan) as db_qkan:
+                        export_kanaldaten(
+                            self.iface,
+                            dynafile,
+                            template_dyna,
+                            db_qkan,
+                            dynabef_choice,
+                            dynaprof_choice,
+                            liste_teilgebiete,
+                            profile_ergaenzen,
+                            autonummerierung_dyna,
+                            mit_verschneidung,
+                            fangradius,
+                            mindestflaeche,
+                            max_loops,
+                        )
                 except QkanAbortError as e:
                     logger.error("Fehler beim Export der Kanaldaten: %s", e)
 

--- a/qkan/swmmporter/_exportSWMM.py
+++ b/qkan/swmmporter/_exportSWMM.py
@@ -57,6 +57,15 @@ class ExportTask:
                     db_qkan
                 ),
             )
+            # i would recommend raising an exception here (or in the fehlermeldung function) otherwise
+            # the process will keep running and eventually crash       
+        if not self.ergfileSwmm:
+            fehlermeldung(
+                "Fehler in Input-Datein:\n",
+                "Es wurde keine Datei unter 'Ergebnisdatei:SWMM (*.INP):' angegeben!"
+            )
+            # i would recommend raising an exception here (or in the fehlermeldung function) otherwise
+            # the process will keep running and eventually crash
 
     def __del__(self) -> None:
         self.db_qkan.sql("SELECT RecoverSpatialIndex()")
@@ -1513,9 +1522,11 @@ class ExportTask:
 
                 for i in liste:
                     while x + 2 <= len(liste) and x < len(liste) - 2:
-
-                        xsch = float(liste[x])
-                        ysch = float(liste[x + 1])
+                        # the prevous process (stripping tripel brackets)
+                        # doesn't handle all cases (i.e. double brackets)
+                        # so its safer to just strip every bracket individually
+                        xsch = float(liste[x].strip("(").strip(")"))
+                        ysch = float(liste[x + 1].strip("(").strip(")"))
                         x += 2
 
                         dataver += f"{name:<16s} {xsch:<18.3f} {ysch:<18.3f}\n"


### PR DESCRIPTION
When exporting to SWMM and dyna the plugin currently exits with an error. The causes are:
Dyna-export:
The database object thats passed to export_kanaldaten is stale by the time the function call is reached. Using another `with DBConnection(dbname=database_qkan) as db_qkan:` block fixes this
SWMM-export:
The current logic to convert the Multipolygon vertices into a list of x and y coords fails if there are more or less then three brackets. Stripping brackets from each item solves this. I doubt this is the best solution, but it worked for my case where the previous code failed.

Also I noticed that the plugin fails without a self explanatory error if no output file was set. A behaviour that i tried to fix (at least a bit)
