### PR TITLE
Don't crash if logging's _acquireLock and _releaseLock don't exist (Python 3.13+)

### DIFF
--- a/qkan/utils.py
+++ b/qkan/utils.py
@@ -143,14 +143,14 @@ def setup_logging(log_to_console: bool, iface) -> tuple[QKanLogger, Path]:
         logger.addHandler(stream_handler)
 
     # inject our logger into global logger registry
-    acquire_lock = getattr(logging, "_acquireLock")
+    acquire_lock = getattr(logging, "_acquireLock", None)
     if acquire_lock is not None and callable(acquire_lock):
         acquire_lock()
     else:
         logger.error_code("logging is missing _acquireLock()")
 
     logging.Logger.manager.loggerDict["QKan"] = logger
-    release_lock = getattr(logging, "_releaseLock")
+    release_lock = getattr(logging, "_releaseLock", None)
     if release_lock is not None and callable(release_lock):
         release_lock()
     else:


### PR DESCRIPTION
Otherwise QKAN crashes on plugin load:

> Couldn't load plugin 'qkan' due to an error when calling its classFactory() method 
> 
> ```
> AttributeError: module 'logging' has no attribute '_acquireLock' 
> Traceback (most recent call last):
>   File "/usr/lib/python3.13/site-packages/qgis/utils.py", line 478, in _startPlugin
>     plugins[packageName] = package.classFactory(iface)
>                            ~~~~~~~~~~~~~~~~~~~~^^^^^^^
>   File "/home/user/.local/share/QGIS/QGIS3/profiles/qkan/python/plugins/qkan/__init__.py", line 53, in classFactory
>     qkan = QKan(iface)
>   File "/home/user/.local/share/QGIS/QGIS3/profiles/qkan/python/plugins/qkan/__init__.py", line 96, in __init__
>     self.logger, self.log_path = setup_logging(LOG_TO_CONSOLE, iface)
>                                  ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/user/.local/share/QGIS/QGIS3/profiles/qkan/python/plugins/qkan/utils.py", line 146, in setup_logging
>     acquire_lock = getattr(logging, "_acquireLock")
> AttributeError: module 'logging' has no attribute '_acquireLock'
> ```
> 

(and the same for `_releaseLock`).

This change adds a default value `None` if the function cannot be found in the `logging` module. The subsequent existing checks work with this.