### PR TITLE
fix(vlc): crash if vlc is not installed

### DIFF
--- a/qkan/datenbankviewer/media_player.py
+++ b/qkan/datenbankviewer/media_player.py
@@ -11,19 +11,13 @@ import os
 import sys
 import json
 import re
-import traceback
 from pathlib import Path
 
 from PyQt5.QtCore import QTimer, QTime, Qt
 from PyQt5.QtWidgets import (
     QDialog,
     QFileDialog,
-    QFrame,
-    QPushButton,
-    QSlider,
-    QLineEdit,
     QMessageBox,
-    QLabel,
 )
 
 from qgis.PyQt import uic
@@ -31,6 +25,10 @@ from qgis.utils import iface
 from qgis.gui import QgsMapToolIdentifyFeature
 from qgis.core import QgsProject
 
+from qkan.tools.vlc_error import VlcLoadError
+from qkan.utils import get_logger
+
+LOGGER = get_logger(__name__)
 
 # =========================================================
 # VLC-Import
@@ -39,8 +37,8 @@ from qgis.core import QgsProject
 try:
     from ..external.vlc import vlc
 except OSError:
-    traceback.print_exc()
-    raise Exception("Could not open/find VLC. Is it installed?")
+    LOGGER.info("Could not open/find VLC. Is it installed?", exc_info=True)
+    vlc = None
 
 
 # =========================================================
@@ -78,6 +76,9 @@ class MediaPlayer(QDialog, FORM_CLASS_MediaPlayer):
         self.video_settings_dialog = (
             VideoSettingsDialog_qkan() if VideoSettingsDialog_qkan else None
         )
+
+        if vlc is None:
+            raise VlcLoadError
 
         # VLC initialisieren
         self.instance = vlc.Instance()
@@ -271,6 +272,9 @@ class MediaPlayer(QDialog, FORM_CLASS_MediaPlayer):
 
     def open_file(self):
         """Öffnet und lädt eine Video-Datei anhand des Dateinamens aus dem UI."""
+        if vlc is None:
+            raise VlcLoadError
+
         video = self.film_dateiname.text()
         if not video:
             return
@@ -451,14 +455,3 @@ class MediaPlayer(QDialog, FORM_CLASS_MediaPlayer):
         except Exception:
             pass
         super().closeEvent(event)
-
-
-# =========================================================
-# Factory-Funktion
-# =========================================================
-
-def open_video(video_path, time=0):
-    """Statische Factory-Funktion zum Öffnen eines Videofensters."""
-    window = MediaPlayer(film_dateiname=video_path)
-    window.show()
-    return window

--- a/qkan/datenbankviewer/ui_handlers.py
+++ b/qkan/datenbankviewer/ui_handlers.py
@@ -9,14 +9,11 @@ Ergänzung für ui_handlers.py - Vollständige Implementierungen der Handler-Met
 import os
 import json
 import subprocess
-from collections import defaultdict
 
 from PyQt5.QtWidgets import (
     QMessageBox,
-    QTableWidget,
     QTabWidget,
     QListWidget,
-    QWidget,
     QVBoxLayout,
     QDialog,
     QDialogButtonBox,
@@ -26,11 +23,16 @@ from qgis.core import QgsProject, QgsPrintLayout, QgsLayoutItemMap
 from qgis.gui import *
 from qgis.utils import iface
 
+from qkan.tools.vlc_error import VlcLoadError
+from qkan.utils import get_logger
+
 from .data_queries import find_inner_table_widget
 from .media_player import MediaPlayer
 from .document_management import DocumentManagementWindow
 from .visualization import CanalVisualizationWindow
 from .sanierung_tool import Sanierungstool
+
+LOGGER = get_logger(__name__)
 
 
 # =========================================================
@@ -97,9 +99,14 @@ def start_video_clicked(self):
     film_dateiname = QLineEdit()
     film_dateiname.setText(video_path)
 
-    media_player = MediaPlayer(film_dateiname=film_dateiname)
-    media_player.show()
-    media_player.exec()
+    try:
+        media_player = MediaPlayer(film_dateiname=film_dateiname)
+        media_player.show()
+        media_player.exec()
+    except VlcLoadError:
+        LOGGER.error_user("Could not open/find VLC. Is it installed?")
+
+
 
 
 # =========================================================

--- a/qkan/tools/videoplayer.py
+++ b/qkan/tools/videoplayer.py
@@ -1,17 +1,19 @@
 import os.path
-import sys
 from PyQt5 import uic
 from PyQt5.QtCore import QTimer, QTime
-from qgis.core import QgsProject
-from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QFrame, QPushButton, QSlider,QApplication
+from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QFrame, QPushButton, QSlider
+
+from qkan.utils import get_logger
+
+from .vlc_error import VlcLoadError
+
+LOGGER = get_logger(__name__)
 
 try:
     from qkan.external.vlc import vlc
 except OSError:
-    import traceback
-
-    traceback.print_exc()
-    raise Exception("Could not open/find VLC. Is it installed?")
+    LOGGER.info("Could not open/find VLC. Is it installed?", exc_info=True)
+    vlc = None
 
 FORM_CLASS_videoplayer, _ = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "res", "videoplayer.ui")
@@ -31,6 +33,9 @@ class Videoplayer(QDialog, FORM_CLASS_videoplayer):
         super().__init__(parent=parent)
 
         self.setupUi(self)
+
+        if vlc is None:
+            raise VlcLoadError
 
         self.instance = vlc.Instance()
         self.mediaplayer = self.instance.media_player_new()
@@ -105,6 +110,9 @@ class Videoplayer(QDialog, FORM_CLASS_videoplayer):
 
     def open_file(self):
         """Open a media file in a MediaPlayer"""
+        if vlc is None:
+            raise VlcLoadError
+
         filename = self.video
         time = self.time
         if filename is None:
@@ -130,9 +138,6 @@ class Videoplayer(QDialog, FORM_CLASS_videoplayer):
         events = self.mediaplayer.event_manager()
         events.event_attach(vlc.EventType.MediaPlayerPositionChanged, self.update_ui)
         self.play_pause()
-        #self.mediaplayer.pause()
-        #self.playpause.setText("Play")
-        #self.isPaused = True
 
 
     def Stop(self):
@@ -186,14 +191,3 @@ class Videoplayer(QDialog, FORM_CLASS_videoplayer):
         mtime = QTime(0, 0, 0, 0)
         self.time = mtime.addMSecs(self.mediaplayer.get_time())
         self.timelabel.setText(self.time.toString())
-
-    @staticmethod
-    def open_video(video: str, time: float):
-        #folder_path = QgsProject.instance().readPath("./")
-        window = Videoplayer(video=video, time=time)
-        window.show()
-        window.open_file()
-        window.exec_()
-
-
-

--- a/qkan/tools/vlc_error.py
+++ b/qkan/tools/vlc_error.py
@@ -1,0 +1,2 @@
+class VlcLoadError(Exception):
+    """Raised if python-vlc is unavailable"""

--- a/qkan/tools/zeige_video.py
+++ b/qkan/tools/zeige_video.py
@@ -1,18 +1,14 @@
-from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem
-from qgis.PyQt.QtCore import QStandardPaths
+from qgis.PyQt.QtWidgets import QDialog
+from qkan.tools.vlc_error import VlcLoadError
 from qkan.utils import get_logger
 from qgis.utils import iface
 from qgis.core import Qgis
-from qgis.core import QgsApplication
 
 import os
 from qkan import QKan
 from qkan.database.dbfunc import DBConnection
 from qkan.tools.videoplayer import Videoplayer
 from qkan.tools.qkan_utils import get_database_QKan
-import json
-import site
-from pathlib import Path
 import sys
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
@@ -68,20 +64,22 @@ class ShowVideo(QDialog):
                 video = video.lower()
                 time_h = 0
                 timecode = self.time_code
-                if timecode == 0:
-                    window = Videoplayer(video=video, time=0)
-                else:
+                if timecode > 0:
                     time_h = int(timecode / 1000000) if timecode > 1000000 else 0
                 time_m = (int(timecode / 10000) if timecode > 10000 else 0) - (time_h * 100)
                 time_s = (int(timecode / 100) if timecode > 100 else 0) - (time_h * 10000) - (time_m * 100)
 
                 video_offset = self.video_offset
                 time = float(time_h / 3600 + time_m / 60 + time_s + video_offset)
-                window = Videoplayer(video=video, time=time)
 
-                window.show()
-                window.open_file()
-                window.exec_()
+                try:
+                    window = Videoplayer(video=video, time=time)
+                except VlcLoadError:
+                    logger.error_user("Could not open/find VLC. Is it installed?")
+                else:
+                    window.show()
+                    window.open_file()
+                    window.exec_()
 
             except ImportError:
                 raise Exception(


### PR DESCRIPTION
Log info on import, raise `VlcLoadError` on use and log user-facing error.